### PR TITLE
Better types, return hexIndex and maxDepth in state getter, fix import

### DIFF
--- a/JsonLow.d.ts
+++ b/JsonLow.d.ts
@@ -1,16 +1,91 @@
+export declare const CodePoint: CodePoint
+export type CodePoint = {
+  _0_: number,
+  _1_: number,
+  _9_: number,
+  _a_: number,
+  _f_: number,
+  _A_: number,
+  _F_: number,
+  _openCurly_: number,
+  _openSquare_: number,
+  _closeCurly_: number,
+  _closeSquare_: number,
+  _quoteMark_: number,
+  _plus_: number,
+  _minus_: number,
+  _space_: number,
+  _newline_: number,
+  _tab_: number,
+  _return_: number,
+  _backslash_: number,
+  _slash_: number,
+  _comma_: number,
+  _colon_: number,
+  _t_: number,
+  _n_: number,
+  _b_: number,
+  _r_: number,
+  _u_: number,
+  _dot_: number,
+  _e_: number,
+  _E_: number,
+  _l_: number,
+  _s_: number,
+}
+export enum JsonFeedbackType {
+  error = 'JsonFeedbackType.error',
+}
+export enum JsonErrorType {
+  unexpected = 'JsonErrorType.unexpected',
+  unexpectedEnd = 'JsonErrorType.unexpectedEnd',
+}
+export declare const error: error
+export type error = (message: string) => {
+  type: JsonFeedbackType.error,
+  message: string,
+}
+export declare const unexpected: unexpected
+export type unexpected = (code: number, context: string, expected: Array<string | [startChar: string, endChar: string]>) => {
+  type: JsonFeedbackType.error,
+  errorType: JsonErrorType.unexpected,
+  codePoint: number,
+  context: string,
+  expected: Array<string | [startChar: string, endChar: string]>,
+}
+export declare const unexpectedEnd: unexpectedEnd
+export type unexpectedEnd = (context?: string, expected?: Array<string | [startChar: string, endChar: string]>) => {
+  type: JsonFeedbackType.error,
+  errorType: JsonErrorType.unexpectedEnd,
+  context?: string,
+  expected?: Array<string | [startChar: string, endChar: string]>,
+}
+export declare const isZeroNine: isZeroNine
+export type isZeroNine = (code: number) => boolean
+export declare const isOneNine: isOneNine
+export type isOneNine = (code: number) => boolean
+export declare const isWhitespace: isWhitespace
+export type isWhitespace = (code: number) => boolean
+export interface JsonLowBaseState {
+  mode: string,
+  parents: string[],
+  isKey: boolean,
+  hexIndex: number,
+  maxDepth: number,
+}
+export interface JsonLowState extends JsonLowBaseState {
+  downstream?: JsonLowState,
+}
+export interface JsonLowInitialState extends Partial<JsonLowBaseState> {
+}
 export declare const JsonLow: JsonLow
 export type JsonLow = <Feedback, End>(
-  next: JsonLowHandlers<Feedback, End>, 
-  initialState?: {
-    mode: string,
-    parents: string[],
-    hexIndex: number,
-    maxDepth: number,
-  }
+  next: JsonLowHandlers<Feedback, End>,
+  initialState?: JsonLowInitialState,
 ) => {
   codePoint(codePoint: number): Feedback,
   end(): End,
-  state(): string,
+  state(): JsonLowState,
 }
 export type JsonLowHandlers<Feedback, End> = {
   openObject?: JsonLowHandler<Feedback>,
@@ -40,7 +115,7 @@ export type JsonLowHandlers<Feedback, End> = {
   comma?: JsonLowHandler<Feedback>,
   colon?: JsonLowHandler<Feedback>,
 
-  state?: () => string,
+  state?: () => JsonLowState,
   end?: () => End,
 }
 export type JsonLowHandler<Feedback> = (codePoint: number) => Feedback

--- a/JsonLow.d.ts
+++ b/JsonLow.d.ts
@@ -40,43 +40,42 @@ export enum JsonErrorType {
   unexpected = 'JsonErrorType.unexpected',
   unexpectedEnd = 'JsonErrorType.unexpectedEnd',
 }
-export declare const error: error
-export type error = (message: string) => {
+export declare const error: (message: string) => {
   type: JsonFeedbackType.error,
   message: string,
 }
-export declare const unexpected: unexpected
-export type unexpected = (code: number, context: string, expected: Array<string | [startChar: string, endChar: string]>) => {
+export declare const unexpected: (code: number, context: string, expected: Array<string | [startChar: string, endChar: string]>) => {
   type: JsonFeedbackType.error,
   errorType: JsonErrorType.unexpected,
   codePoint: number,
   context: string,
   expected: Array<string | [startChar: string, endChar: string]>,
 }
-export declare const unexpectedEnd: unexpectedEnd
-export type unexpectedEnd = (context?: string, expected?: Array<string | [startChar: string, endChar: string]>) => {
+export declare const unexpectedEnd: (context?: string, expected?: Array<string | [startChar: string, endChar: string]>) => {
   type: JsonFeedbackType.error,
   errorType: JsonErrorType.unexpectedEnd,
   context?: string,
   expected?: Array<string | [startChar: string, endChar: string]>,
 }
-export declare const isZeroNine: isZeroNine
-export type isZeroNine = (code: number) => boolean
-export declare const isOneNine: isOneNine
-export type isOneNine = (code: number) => boolean
-export declare const isWhitespace: isWhitespace
-export type isWhitespace = (code: number) => boolean
+export declare const isZeroNine: (code: number) => boolean
+export declare const isOneNine: (code: number) => boolean
+export declare const isWhitespace: (code: number) => boolean
+export interface JsonLowBaseConfig {
+  maxDepth: number,
+}
+export interface JsonLowConfig extends JsonLowBaseConfig {
+  downstream?: JsonLowConfig,
+}
 export interface JsonLowBaseState {
   mode: string,
   parents: string[],
   isKey: boolean,
   hexIndex: number,
-  maxDepth: number,
 }
 export interface JsonLowState extends JsonLowBaseState {
   downstream?: JsonLowState,
 }
-export interface JsonLowInitialState extends Partial<JsonLowBaseState> {
+export interface JsonLowInitialState extends Partial<JsonLowBaseState>, Partial<JsonLowBaseConfig> {
 }
 export declare const JsonLow: JsonLow
 export type JsonLow = <Feedback, End>(
@@ -86,6 +85,7 @@ export type JsonLow = <Feedback, End>(
   codePoint(codePoint: number): Feedback,
   end(): End,
   state(): JsonLowState,
+  config(): JsonLowConfig,
 }
 export type JsonLowHandlers<Feedback, End> = {
   openObject?: JsonLowHandler<Feedback>,
@@ -116,6 +116,7 @@ export type JsonLowHandlers<Feedback, End> = {
   colon?: JsonLowHandler<Feedback>,
 
   state?: () => JsonLowState,
+  config?: () => JsonLowConfig,
   end?: () => End,
 }
 export type JsonLowHandler<Feedback> = (codePoint: number) => Feedback

--- a/JsonLow.d.ts
+++ b/JsonLow.d.ts
@@ -86,7 +86,7 @@ export declare const JsonLow: <Feedback, End, DownstreamState = unknown, Downstr
   initialState?: JsonLowInitialState,
 ) => {
   codePoint(codePoint: number): Feedback | JsonStandardFeedback | undefined,
-  end(): End | JsonStandardEnd,
+  end(): End | JsonStandardEnd | undefined,
   state(): JsonLowState<DownstreamState>,
   config(): JsonLowConfig<DownstreamConfig>,
 }

--- a/JsonLow.js
+++ b/JsonLow.js
@@ -406,7 +406,7 @@ export const JsonLow = (next, initialState = {}) => {
     },
     state: () => {
       const downstream = next.state?.()
-      return {mode, parents: [...parents], isKey, downstream}
+      return {mode, parents: [...parents], isKey, downstream, hexIndex, maxDepth}
     },
   }
   return self

--- a/JsonLow.js
+++ b/JsonLow.js
@@ -406,7 +406,11 @@ export const JsonLow = (next, initialState = {}) => {
     },
     state: () => {
       const downstream = next.state?.()
-      return {mode, parents: [...parents], isKey, downstream, hexIndex, maxDepth}
+      return {mode, parents: [...parents], isKey, hexIndex, downstream}
+    },
+    config: () => {
+      const downstream = next.config?.()
+      return {maxDepth, downstream}
     },
   }
   return self

--- a/mod.d.ts
+++ b/mod.d.ts
@@ -1,0 +1,3 @@
+export * from './JsonHigh.js'
+export * from './JsonLowToHigh.js'
+export * from './JsonLow.js'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "mod.js",
+    "mod.d.ts",
     "JsonLow.js",
     "JsonLow.d.ts",
     "JsonHigh.js",


### PR DESCRIPTION
The package can't be imported in typescript because `mod.js` is missing a type definition file. This PR creates a `mod.d.ts` file which fixes this issue. It also fixes some type definitions, add missing type definitions, and makes the `state()` method return hexIndex and maxDepth so that the state can be properly restored; without this, hexIndex has to be tracked separately and maxDepth has to be saved from the initialState, which is a pain